### PR TITLE
feat: Add group-based access control for OIDC users

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,7 +40,12 @@ OIDC_CLIENT_SECRET=your-client-secret
 
 # ===== Access Control Configuration =====
 # Allowed email addresses (comma-separated list of who can access the app - used with OIDC)
+# NOTE: Use either ALLOWED_EMAILS or ALLOWED_GROUPS, not both. Groups take precedence.
 # ALLOWED_EMAILS=dev@example.com,family@example.com
+
+# Allowed groups from OIDC provider (comma-separated list)
+# NOTE: Use either ALLOWED_EMAILS or ALLOWED_GROUPS, not both. Groups take precedence.
+# ALLOWED_GROUPS=family,admin,users
 
 # ===== Local Users Configuration (when OIDC is disabled) =====
 # Local users list (simple names in a comma-separated list)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ Copy `.env.sample` to `.env` and fill in your values, or edit the environment va
 **For OIDC mode (OIDC_ENABLED=true):**
 - `OIDC_BASE_URL` - Your authentication provider URL
 - `OIDC_CLIENT_ID` & `OIDC_CLIENT_SECRET` - From your OIDC provider
-- `ALLOWED_EMAILS` - Who can access the app
+- **Access Control:** Choose ONE of the following:
+  - `ALLOWED_GROUPS` - Comma-separated list of OIDC groups (recommended)
+  - `ALLOWED_EMAILS` - Comma-separated list of email addresses
+  - **Note:** If both are set, `ALLOWED_GROUPS` takes precedence
 
 **For Local mode (OIDC_ENABLED=false):**
 - `USERS` - Local users in format: `username1,username2,username3`
@@ -105,6 +108,9 @@ python app.py
 **Common issues:**
 - **Can't login?** Check your OIDC callback URL is set correctly
 - **OIDC errors?** Verify your client ID/secret and base URL
-- **Access denied?** Add your email to `ALLOWED_EMAILS`
+- **Access denied?** 
+  - If using groups: Ensure user is in an `ALLOWED_GROUPS` group
+  - If using emails: Add your email to `ALLOWED_EMAILS`
+  - Make sure your OIDC provider includes groups in the token (if using groups)
 
 The app uses OIDC auto-discovery but falls back to manual configuration if needed.

--- a/compose.yml
+++ b/compose.yml
@@ -26,8 +26,12 @@ services:
       - OIDC_CLIENT_SECRET=your-client-secret
       
       # ===== Access Control Configuration =====
+      # NOTE: Use either ALLOWED_EMAILS or ALLOWED_GROUPS, not both. Groups take precedence.
       # Allowed email addresses (comma-separated list of who can access the app - used with OIDC)
-      - ALLOWED_EMAILS=user1@example.com,user2@example.com,admin@example.com
+      # - ALLOWED_EMAILS=user1@example.com,user2@example.com,admin@example.com
+      
+      # Allowed groups from OIDC provider (comma-separated list)
+      - ALLOWED_GROUPS=family,admin,users
       
       # ===== Local Users Configuration (when OIDC is disabled) =====
       # Local users list (simple names or full format username:email:Full Name)

--- a/config.py
+++ b/config.py
@@ -125,13 +125,23 @@ def get_oidc_configuration():
 def load_access_control():
     """Load access control configuration"""
     config = {
-        'allowed_emails': []
+        'allowed_emails': [],
+        'allowed_groups': []
     }
     
-    # Load from environment variables
-    allowed_emails_str = os.getenv('ALLOWED_EMAILS', '')
-    if allowed_emails_str:
-        config['allowed_emails'] = [email.strip() for email in allowed_emails_str.split(',')]
+    # Load allowed groups from environment variables (takes precedence)
+    allowed_groups_str = os.getenv('ALLOWED_GROUPS', '')
+    if allowed_groups_str:
+        config['allowed_groups'] = [group.strip() for group in allowed_groups_str.split(',')]
+        logger.info(f"Access control: Using ALLOWED_GROUPS with {len(config['allowed_groups'])} groups")
+    else:
+        # Load allowed emails only if groups are not configured
+        allowed_emails_str = os.getenv('ALLOWED_EMAILS', '')
+        if allowed_emails_str:
+            config['allowed_emails'] = [email.strip() for email in allowed_emails_str.split(',')]
+            logger.info(f"Access control: Using ALLOWED_EMAILS with {len(config['allowed_emails'])} emails")
+        else:
+            logger.warning("No access control configured (neither ALLOWED_GROUPS nor ALLOWED_EMAILS)")
     
     # Add allowed domains for redirect validation
     base_url = os.getenv('BASE_URL', 'http://localhost:5000')

--- a/templates/unauthorized.html
+++ b/templates/unauthorized.html
@@ -63,6 +63,11 @@
                     </h3>
                     <div class="mt-2 text-sm text-blue-700 dark:text-blue-300">
                         <p>Contact your administrator to request access to this application.</p>
+                        <p class="mt-2">They will need to either:</p>
+                        <ul class="list-disc ml-5 mt-1 space-y-1">
+                            <li>Add you to an authorized group in the OIDC provider, or</li>
+                            <li>Add your email to the ALLOWED_EMAILS or ALLOWED_GROUPS configuration</li>
+                        </ul>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Allow OIDC groups to control access to Homie. If the user has access to the OIDC application, but is not specified inside of Homie, the user will receive an error landing page.
```
# Allowed groups from OIDC provider (comma-separated list)
- ALLOWED_GROUPS=family,admin,users
```